### PR TITLE
fix!: change default working-directory from .github/tf to .tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ permissions:
 | Input | Required | Default | Description |
 |---|---|---|---|
 | `github-token` | Yes | | GitHub token |
-| `working-directory` | No | `.github/tf` | Directory containing OpenTofu configuration |
+| `working-directory` | No | `.tf` | Directory containing OpenTofu configuration |
 
 ## Behavior
 

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   github-token:
     required: true
   working-directory:
-    default: .github/tf
+    default: .tf
 
 runs:
   using: composite


### PR DESCRIPTION
## Summary

- Change \`working-directory\` default from \`.github/tf\` to \`.tf\`

\`.github/\` is reserved for GitHub-specific files (workflows, issue templates, etc.).
Infrastructure configuration doesn't belong there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)