### PR TITLE
fix: don't auto-apply when import has config changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,8 +25,7 @@ runs:
         tofu plan -out="$tfplan" || true
         if tofu show -json "$tfplan" | jq -e '
              [.resource_changes[]? |
-              select(.change.actions != ["no-op"] and .change.actions != ["read"]) |
-              select(.change | has("importing") | not)] | length == 0
+              select(.change.actions != ["no-op"] and .change.actions != ["read"])] | length == 0
            '; then
           tofu apply -auto-approve "$tfplan"
         fi


### PR DESCRIPTION
## Summary

Imports that require config changes have `actions: ["update"]` alongside the `importing` key. The previous jq expression excluded all resources with an `importing` key, making the check incorrectly treat "import + change" plans as import-only.

Clean imports already produce `actions: ["no-op"]` and are handled by the first `select` — the second `select` was both redundant and wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)