### PR TITLE
feat: declare Dependabot labels as code

### DIFF
--- a/.tf/label.tf
+++ b/.tf/label.tf
@@ -9,7 +9,6 @@ locals {
   }
 }
 
-
 import {
   id = "repo-settings-as-code:dependencies"
   to = github_issue_label.dependabot["dependencies"]

--- a/.tf/label.tf
+++ b/.tf/label.tf
@@ -1,0 +1,41 @@
+# Dependabot's labels, with the colours and descriptions it uses when it
+# auto-creates them. A repository whose dependabot.yml sets a custom `labels:`
+# must declare them up front, because Dependabot does not create labels it was
+# told to use; it only auto-creates the defaults. The full set lives here so it
+# can be reused: copy this file into another repo's OpenTofu config and set
+# `enabled` to the labels that repo's dependabot.yml references.
+#
+# For a repo where Dependabot has not created these yet, drop the import blocks
+# below and OpenTofu will create them; keep an import block for any label that
+# already exists (as the two here do).
+locals {
+  dependabot_labels = {
+    dependencies   = { color = "0366d6", description = "Pull requests that update a dependency file" }
+    docker         = { color = "21ceff", description = "Pull requests that update Docker code" }
+    github_actions = { color = "000000", description = "Pull requests that update GitHub Actions code" }
+    javascript     = { color = "168700", description = "Pull requests that update JavaScript code" }
+    php            = { color = "45229e", description = "Pull requests that update Php code" }
+    ruby           = { color = "ce2d2d", description = "Pull requests that update Ruby code" }
+  }
+
+  # The labels this repository's dependabot.yml uses.
+  enabled_dependabot_labels = ["dependencies", "github_actions"]
+}
+
+resource "github_issue_label" "dependabot" {
+  for_each = toset(local.enabled_dependabot_labels)
+
+  repository  = github_repository.this.name
+  name        = each.key
+  color       = local.dependabot_labels[each.key].color
+  description = local.dependabot_labels[each.key].description
+}
+
+import {
+  id = "repo-settings-as-code:dependencies"
+  to = github_issue_label.dependabot["dependencies"]
+}
+import {
+  id = "repo-settings-as-code:github_actions"
+  to = github_issue_label.dependabot["github_actions"]
+}

--- a/.tf/label.tf
+++ b/.tf/label.tf
@@ -1,13 +1,3 @@
-# Dependabot's labels, with the colours and descriptions it uses when it
-# auto-creates them. A repository whose dependabot.yml sets a custom `labels:`
-# must declare them up front, because Dependabot does not create labels it was
-# told to use; it only auto-creates the defaults. The full set lives here so it
-# can be reused: copy this file into another repo's OpenTofu config and set
-# `enabled` to the labels that repo's dependabot.yml references.
-#
-# For a repo where Dependabot has not created these yet, drop the import blocks
-# below and OpenTofu will create them; keep an import block for any label that
-# already exists (as the two here do).
 locals {
   dependabot_labels = {
     dependencies   = { color = "0366d6", description = "Pull requests that update a dependency file" }
@@ -17,19 +7,8 @@ locals {
     php            = { color = "45229e", description = "Pull requests that update Php code" }
     ruby           = { color = "ce2d2d", description = "Pull requests that update Ruby code" }
   }
-
-  # The labels this repository's dependabot.yml uses.
-  enabled_dependabot_labels = ["dependencies", "github_actions"]
 }
 
-resource "github_issue_label" "dependabot" {
-  for_each = toset(local.enabled_dependabot_labels)
-
-  repository  = github_repository.this.name
-  name        = each.key
-  color       = local.dependabot_labels[each.key].color
-  description = local.dependabot_labels[each.key].description
-}
 
 import {
   id = "repo-settings-as-code:dependencies"
@@ -38,4 +17,15 @@ import {
 import {
   id = "repo-settings-as-code:github_actions"
   to = github_issue_label.dependabot["github_actions"]
+}
+resource "github_issue_label" "dependabot" {
+  for_each = toset([
+    "dependencies",
+    "github_actions",
+  ])
+
+  repository  = github_repository.this.name
+  name        = each.key
+  color       = local.dependabot_labels[each.key].color
+  description = local.dependabot_labels[each.key].description
 }


### PR DESCRIPTION
Declares the Dependabot labels (currently `dependencies` and `github_actions`, both already created by Dependabot) as `github_issue_label` resources, with the exact colours and descriptions Dependabot uses when auto-creating them.

Why: a repo whose `dependabot.yml` sets a custom `labels:` must create those labels up front, since Dependabot only auto-creates its defaults. `label.tf` carries the full canonical set so it can be copied into another repo's config (adjust the `enabled` list).

`tofu plan` shows both labels importing as no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)